### PR TITLE
Update n8n-eks-cluster.ts to check for wildcard and root ssl certificate in certificate manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@aws-quickstart/eks-blueprints": "^1.12.0",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "aws-sdk": "^2.1128.0"
   }
 }


### PR DESCRIPTION
The template changes are done to create only SSL certificates if they are not present in the certificate manager. if they are already imported then the creation of certificates is skipped.